### PR TITLE
temporary disable docusaurus colorMode switch 

### DIFF
--- a/apps/docs/docusaurus.config.js
+++ b/apps/docs/docusaurus.config.js
@@ -187,6 +187,12 @@ const config = {
 				myFont: ['Inter', 'sans-serif'],
 				myOtherFont: ['-apple-system', 'system-ui', 'sans-serif'],
 			},
+			// TODO: fixed dark mode color issue and removed this colorMode object
+			colorMode: {
+				defaultMode: 'light',
+				disableSwitch: false,
+				respectPrefersColorScheme: false,
+			},
 			navbar: {
 				// hideOnScroll: true,
 				logo: {

--- a/apps/docs/src/css/custom.css
+++ b/apps/docs/src/css/custom.css
@@ -611,9 +611,17 @@ nav.navbar .navbar__inner {
   @apply mr-3;
 }
 
-.header-github-link {
+/* TODO: uncomment when dark mode color issue fixed */
+/* .header-github-link {
   @apply mr-4;
+} */
+
+/* TODO: removed wehn dark mode color issue fixed */
+[class*="colorModeToggle_"] {
+  @apply hidden !important;
 }
+
+/* --- End --- */
 
 .header-github-link:before {
   @apply w-[18px] h-[18px] flex;


### PR DESCRIPTION
Found some color issues in dark mode on the documentation site. colorMode switch is disabled temporarily until we fixed those issues.