### PR TITLE
fix accordion type issue

### DIFF
--- a/packages/ui/src/components/accordion/accordion-header.tsx
+++ b/packages/ui/src/components/accordion/accordion-header.tsx
@@ -8,7 +8,7 @@ type AccordionHeaderProps = {
   children:
     | React.ReactNode
     | (({ open }: { open: boolean }) => React.ReactNode);
-} & React.ButtonHTMLAttributes<HTMLButtonElement>;
+} & Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, 'children'>;
 
 export const AccordionHeader = React.forwardRef<
   HTMLButtonElement,


### PR DESCRIPTION
fixed accordion type issue.

Example code in [rizz ui accordion](https://www.rizzui.com/docs/data-display/accordion) did not work.
HtmlButton Children has typeof string, so with intersection resulting type is  ReactNode & string type.

I fixed using Omit type selector to accepts as 
({open}) => ReactNode,
not ({open}) => ReactNode & string.
