### PR TITLE
Fix: Prevent empty label element creation in Progressbar component

### DIFF
--- a/packages/ui/src/components/progressbar/progressbar.tsx
+++ b/packages/ui/src/components/progressbar/progressbar.tsx
@@ -113,7 +113,7 @@ export function Progressbar({
           style={{ width: `${value}%` }}
           {...props}
         >
-          {isInsideBar ? (
+          {isInsideBar && label ? (
             <ProgressbarLabel
               size={size}
               label={label}
@@ -122,7 +122,7 @@ export function Progressbar({
           ) : null}
         </div>
       </div>
-      {!isInsideBar ? (
+      {!isInsideBar && label ? (
         <ProgressbarLabel
           size={size}
           label={label}


### PR DESCRIPTION
## Bug: Progressbar component creates unwanted empty label element

### Description
The Progressbar component creates an empty label element (`<p class="rizzui-text-p rizzui-progressbar-label text-sm font-bold"></p>`) even when:
- No label prop is provided
- label prop is set to undefined
- label prop is set to null

This empty element causes an unwanted layout shift due to its flexbox positioning.

### Steps to reproduce
1. Create a Progressbar component without a label prop:
```jsx
<Progressbar value={50} />
```

2. Inspect the DOM to see the empty label element being created

### Expected behavior
- When no label is provided, no label element should be created in the DOM
- The label element should only be created when a label value is explicitly provided

### Current behavior
- An empty label element is always created
- This element affects the layout due to flexbox positioning

### Solution
Added additional verification to check if label exists before rendering the ProgressbarLabel component, preventing the creation of empty label elements in the DOM.

### Additional context
This fixes issues in layouts where precise positioning is needed, eliminating the need for workarounds like `labelClassName="hidden"` to prevent layout shifts.