### PR TITLE
Fix: Resolve height issue in Select with label and inPortal=false

### DIFF
--- a/packages/ui/src/components/select/select.tsx
+++ b/packages/ui/src/components/select/select.tsx
@@ -320,7 +320,12 @@ export function Select<OptionType extends SelectOption>({
               </Label>
             )}
 
-            <div className={cn('h-full', !inPortal && 'relative')}>
+            <div
+              className={cn(
+                !inPortal && 'relative',
+                !inPortal && label ? 'h-auto' : 'h-full'
+              )}
+            >
               <ListboxButton
                 className={cn(
                   makeClassName(`select-button`),


### PR DESCRIPTION
## Bug: Select component has layout issues when used with label and inPortal=false

### Description
The Select component creates layout issues when both conditions are met:
- The `label` prop is provided
- The `inPortal` prop is set to `false`

This happens because when `inPortal` is `false`, a `relative` class is applied to a div that already has `h-full`, while the label takes up space, creating a layout conflict.

### Steps to reproduce
Create a Select component with `inPortal={false}` and a label:
```jsx
<Select 
  label="Label"
  inPortal={false}
  options={[...]} 
/>
```

### Current behavior
- The container div has both `h-full` and `relative` classes
- The label takes up space above the select
- This creates spacing and positioning issues

### Solution
Modified the conditional class application to properly handle the case when both `inPortal` is `false` and a `label` is provided:

```jsx
className={cn(
  !inPortal && 'relative',
  !inPortal && label ? 'h-auto' : 'h-full'
)}
```

This ensures that when both conditions are met, the `h-full` class is replaced with `h-auto`, allowing proper layout rendering.

### Alternative Workaround
Before this fix, a workaround was to add `className="[&_div.h-full]:!h-auto"` to the Select component.